### PR TITLE
calyptia: add RHCC image

### DIFF
--- a/.github/workflows/calyptia-rhcc.yaml
+++ b/.github/workflows/calyptia-rhcc.yaml
@@ -29,7 +29,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build the staging image
+    - name: Build the test image
       uses: docker/build-push-action@v2
       with:
         file: ./calyptia/ubi8/Dockerfile
@@ -71,7 +71,7 @@ jobs:
           raw,ubi8-${{ inputs.version }}
           raw,ubi8
 
-    - name: Build the staging image
+    - name: Build the production image
       uses: docker/build-push-action@v2
       with:
         file: ./calyptia/ubi8/Dockerfile

--- a/.github/workflows/calyptia-rhcc.yaml
+++ b/.github/workflows/calyptia-rhcc.yaml
@@ -11,40 +11,10 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  calyptia-rhcc-tests:
-    name: RHCC - Run Fluent Bit tests
-    runs-on: [ ubuntu-latest ]
-    environment: staging
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-
-    - name: Log in to the Container registry
-      uses: docker/login-action@v1
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Build the test image
-      uses: docker/build-push-action@v2
-      with:
-        file: ./calyptia/ubi8/Dockerfile
-        context: ./calyptia/ubi8/
-        platforms: linux/amd64
-        push: false
-        load: false
-        build-args: |
-          target=test
-
   calyptia-rhcc-deploy-staging-images:
     name: RHCC - Build multi-arch UBI 8 container images
-    runs-on: [ ubuntu-latest ]
-    needs: calyptia-rhcc-tests
-    environment: staging
+    runs-on: ubuntu-latest
+    environment: rhcc
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -61,6 +31,17 @@ jobs:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and run the tests
+      continue-on-error: true
+      uses: docker/build-push-action@v2
+      with:
+        file: ./calyptia/ubi8/Dockerfile
+        context: ./calyptia/ubi8/
+        platforms: linux/amd64
+        push: false
+        load: false
+        target: test
 
     - name: Extract metadata from Github
       id: meta
@@ -81,5 +62,4 @@ jobs:
         platforms: linux/amd64, linux/arm64
         push: true
         load: false
-        build-args: |
-          target=production
+        target: production

--- a/.github/workflows/calyptia-rhcc.yaml
+++ b/.github/workflows/calyptia-rhcc.yaml
@@ -1,0 +1,85 @@
+---
+name: Deploy RHCC containers to staging
+
+on:
+  workflow_dispatch:
+  push:
+
+env:
+  # Containers
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  calyptia-rhcc-tests:
+    name: RHCC - Run Fluent Bit tests
+    runs-on: [ ubuntu-latest ]
+    environment: staging
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build the staging image
+      uses: docker/build-push-action@v2
+      with:
+        file: ./calyptia/ubi8/Dockerfile
+        context: ./calyptia/ubi8/
+        platforms: linux/amd64
+        push: false
+        load: false
+        build-args: |
+          target=test
+
+  calyptia-rhcc-deploy-staging-images:
+    name: RHCC - Build multi-arch UBI 8 container images
+    runs-on: [ ubuntu-latest ]
+    needs: calyptia-rhcc-tests
+    environment: staging
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata from Github
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          raw,ubi8-${{ inputs.version }}
+          raw,ubi8
+
+    - name: Build the staging image
+      uses: docker/build-push-action@v2
+      with:
+        file: ./calyptia/ubi8/Dockerfile
+        context: ./calyptia/ubi8/
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        platforms: linux/amd64, linux/arm64
+        push: true
+        load: false
+        build-args: |
+          target=production

--- a/calyptia/README.md
+++ b/calyptia/README.md
@@ -1,0 +1,1 @@
+This directory contains all Calyptia customisation, the intent is to keep it all together.

--- a/calyptia/ubi8/Dockerfile
+++ b/calyptia/ubi8/Dockerfile
@@ -55,15 +55,15 @@ RUN make -j $(getconf _NPROCESSORS_ONLN)
 RUN install bin/fluent-bit /fluent-bit/bin/
 
 # Configuration files
-COPY conf/fluent-bit.conf \
-     conf/parsers.conf \
-     conf/parsers_ambassador.conf \
-     conf/parsers_java.conf \
-     conf/parsers_extra.conf \
-     conf/parsers_openstack.conf \
-     conf/parsers_cinder.conf \
-     conf/plugins.conf \
-     /fluent-bit/etc/
+RUN cp -f /tmp/fluent-bit/conf/fluent-bit.conf \
+    /tmp/fluent-bit/conf/parsers.conf \
+    /tmp/fluent-bit/onf/parsers_ambassador.conf \
+    /tmp/fluent-bit/conf/parsers_java.conf \
+    /tmp/fluent-bit/conf/parsers_extra.conf \
+    /tmp/fluent-bit/conf/parsers_openstack.conf \
+    /tmp/fluent-bit/conf/parsers_cinder.conf \
+    /tmp/fluent-bit/conf/plugins.conf \
+    /fluent-bit/etc/
 
 FROM builder as test
 WORKDIR /tmp/fluent-bit/build/

--- a/calyptia/ubi8/Dockerfile
+++ b/calyptia/ubi8/Dockerfile
@@ -57,7 +57,7 @@ RUN install bin/fluent-bit /fluent-bit/bin/
 # Configuration files
 RUN cp -f /tmp/fluent-bit/conf/fluent-bit.conf \
     /tmp/fluent-bit/conf/parsers.conf \
-    /tmp/fluent-bit/onf/parsers_ambassador.conf \
+    /tmp/fluent-bit/conf/parsers_ambassador.conf \
     /tmp/fluent-bit/conf/parsers_java.conf \
     /tmp/fluent-bit/conf/parsers_extra.conf \
     /tmp/fluent-bit/conf/parsers_openstack.conf \

--- a/calyptia/ubi8/Dockerfile
+++ b/calyptia/ubi8/Dockerfile
@@ -1,0 +1,104 @@
+FROM registry.access.redhat.com/ubi8/ubi:8.5 as builder
+# hadolint ignore=DL3041
+RUN dnf update -y && dnf install -y cmake3 curl diffutils gcc gcc-c++ libpq-devel m4 make openssl-devel systemd-devel tar unzip && dnf clean all
+
+# Provide the dependencies for record accessor built from source
+ARG BISON_VER=3.7
+ARG BISON_URL=http://ftp.gnu.org/gnu/bison
+ARG FLEX_VER=2.6.4
+ARG FLEX_URL=https://github.com/westes/flex/files/981163
+ADD ${BISON_URL}/bison-${BISON_VER}.tar.gz /bison/
+ADD ${FLEX_URL}/flex-${FLEX_VER}.tar.gz /flex/
+RUN tar -xzvf /bison/bison-${BISON_VER}.tar.gz -C /bison/ && tar -xzvf /flex/flex-${FLEX_VER}.tar.gz -C /flex/
+
+# Flex needs Bison so do first
+WORKDIR /bison/bison-${BISON_VER}/
+RUN ./configure && make && make install
+WORKDIR /flex/flex-${FLEX_VER}/
+RUN ./configure && make && make install
+
+# Fluent Bit version
+ENV FLB_MAJOR 1
+ENV FLB_MINOR 8
+ENV FLB_PATCH 11
+ENV FLB_VERSION 1.8.11
+
+# Note we use the upstream source directly here
+ARG FLB_TARBALL=https://github.com/fluent/fluent-bit/archive/v$FLB_VERSION.tar.gz
+ENV FLB_SOURCE $FLB_TARBALL
+RUN mkdir -p /fluent-bit/bin /fluent-bit/etc /fluent-bit/log /tmp/fluent-bit-master/
+
+RUN curl -L -o "/tmp/fluent-bit.tar.gz" ${FLB_SOURCE} \
+    && mkdir -p /tmp/fluent-bit \
+    && tar zxfv /tmp/fluent-bit.tar.gz -C /tmp/fluent-bit --strip-components=1 \
+    && rm -rf /tmp/fluent-bit/build/*
+
+WORKDIR /tmp/fluent-bit/build/
+# IPv6 tests dependent on docker configuration and support so disable
+RUN sed -i '/{ "ipv6_client_server", test_ipv6_client_server},/d' ../tests/internal/network.c
+# TODO check if we need to disable the TD output plugin & Process input plugin as unit test fails
+RUN cmake -DFLB_RELEASE=On \
+          -DFLB_TRACE=Off \
+          -DFLB_JEMALLOC=On \
+          -DFLB_TLS=On \
+          -DFLB_SHARED_LIB=Off \
+          -DFLB_EXAMPLES=Off \
+          -DFLB_HTTP_SERVER=On \
+          -DFLB_IN_SYSTEMD=On \
+          -DFLB_OUT_KAFKA=On \
+          -DFLB_OUT_PGSQL=On \
+          -DFLB_TESTS_INTERNAL=On \
+          -DFLB_TESTS_RUNTIME=On \
+          ..
+
+RUN make -j $(getconf _NPROCESSORS_ONLN)
+RUN install bin/fluent-bit /fluent-bit/bin/
+
+# Configuration files
+COPY conf/fluent-bit.conf \
+     conf/parsers.conf \
+     conf/parsers_ambassador.conf \
+     conf/parsers_java.conf \
+     conf/parsers_extra.conf \
+     conf/parsers_openstack.conf \
+     conf/parsers_cinder.conf \
+     conf/plugins.conf \
+     /fluent-bit/etc/
+
+FROM builder as test
+WORKDIR /tmp/fluent-bit/build/
+RUN make test
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5 as production
+RUN microdnf update && microdnf install -y openssl libpq systemd-libs shadow-utils && microdnf clean all
+
+ARG FLUENT_BIT_VER=1.8.11
+ENV FLUENTBIT_VERSION=$FLUENT_BIT_VER
+
+ARG PROD_VERSION
+ENV PROD_VERSION=$PROD_VERSION
+
+# https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/program-on-boarding/technical-prerequisites#dockerfile-requirements
+# The following labels must exist: name, maintainer, vendor, version, release, summary & description.
+LABEL name="calyptia/fluent-bit" \
+      vendor="calyptia" \
+      maintainer="Patrick Stephens <pat@calyptia.com>" \
+      version="ubi8-${FLUENT_BIT_VER}" \
+      release="${FLUENT_BIT_VER}" \
+      summary="Calyptia Fluent Bit ${PROD_VERSION}" \
+      description="Calyptia Fluent Bit ${PROD_VERSION} based on upstream Fluent Bit"
+
+EXPOSE 2020
+
+ENTRYPOINT [ "/fluent-bit/bin/fluent-bit" ]
+CMD [ "/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf" ]
+
+# Ensure we add licensing and help information for certification requirements
+COPY licenses/* /licenses/
+COPY README.md /help.1
+
+COPY --from=builder /fluent-bit /fluent-bit
+
+# Run as non-root user - pick a random one
+RUN useradd -u 9876 -m -s /bin/false fluent-bit
+USER 9876

--- a/calyptia/ubi8/README.md
+++ b/calyptia/ubi8/README.md
@@ -1,0 +1,5 @@
+The Redhat Container Catalog image for Fluent Bit provided by [Calyptia](https://calyptia.com/).
+
+This is the vanilla upstream source code just built and maintained by Calyptia.
+
+[Contact Calyptia](https://calyptia.com/contact/) for more details.

--- a/calyptia/ubi8/licenses/fluent-bit.txt
+++ b/calyptia/ubi8/licenses/fluent-bit.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS


### PR DESCRIPTION
Basic RHCC image support.

Currently trying to keep all Calyptia changes as localised as possible to make merging, etc. easier

Signed-off-by: Patrick Stephens <pat@calyptia.com>

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
